### PR TITLE
Explicitly set the name to the VirtualBox VM to `basic-phishing-site`.

### DIFF
--- a/train-the-trainers/black-hat-bash-back/basic-phishing-website/Vagrantfile
+++ b/train-the-trainers/black-hat-bash-back/basic-phishing-website/Vagrantfile
@@ -9,6 +9,9 @@
 Vagrant.configure("2") do |config|
   config.vm.box = "ubuntu/bionic64"
   config.vm.network "public_network"
+  config.vm.provider "virtualbox" do |v|
+    v.name = "basic-phishing-site"
+  end
   config.vm.provision "shell", path: "provision.sh"
   config.vm.post_up_message = <<~HEREDOC
 


### PR DESCRIPTION
By explicitly setting the name of the VirtualBox VM, we can avoid an error caused by VirtualBox appending the random ID string it usually does with Vagrant-managed VMs, which makes the name of the VM (`vb.name`) too long.

_Without_ doing this, we will hit an error thrown by Vagrant:

```
==> default: Booting VM...
There was an error while executing `VBoxManage`, a CLI used by Vagrant
for controlling VirtualBox. The command and stderr is shown below.

Command: ["startvm", "d72d48e2-e432-4ba6-9e12-2bea611747bf", "--type", "headless"]

Stderr: VBoxManage: error: The specified string / bytes buffer was to small. Specify a larger one and retry. (VERR_CFGM_NOT_ENOUGH_SPACE)
VBoxManage: error: Details: code NS_ERROR_FAILURE (0x80004005), component ConsoleWrap, interface IConsole
```

This has been tested and experienced on both Fedora 28 as well as Ubuntu 18.04.